### PR TITLE
Added random state to the constructor of RCTree

### DIFF
--- a/rrcf/rrcf.py
+++ b/rrcf/rrcf.py
@@ -56,7 +56,9 @@ class RCTree:
     >>> tree.forget_point(100)
     """
 
-    def __init__(self, X=None, index_labels=None, precision=9):
+    def __init__(self, X=None, index_labels=None, precision=9, seed=42):
+        # Random number generation with provided seed
+        self.rng = np.random.RandomState(seed)
         # Initialize dict for leaves
         self.leaves = {}
         # Initialize tree root
@@ -134,9 +136,9 @@ class RCTree:
         l = xmax - xmin
         l /= l.sum()
         # Determine dimension to cut
-        q = np.random.choice(self.ndim, p=l)
+        q = self.rng.choice(self.ndim, p=l)
         # Determine value for split
-        p = np.random.uniform(xmin[q], xmax[q])
+        p = self.rng.uniform(xmin[q], xmax[q])
         # Determine subset of points to left
         S1 = (X[:, q] <= p) & (S)
         # Determine subset of points to right
@@ -834,7 +836,7 @@ class RCTree:
         bbox_hat[-1, :] = np.maximum(bbox[-1, :], point)
         b_span = bbox_hat[-1, :] - bbox_hat[0, :]
         b_range = b_span.sum()
-        r = np.random.uniform(0, b_range)
+        r = self.rng.uniform(0, b_range)
         span_sum = np.cumsum(b_span)
         cut_dimension = np.inf
         for j in range(len(span_sum)):

--- a/rrcf/rrcf.py
+++ b/rrcf/rrcf.py
@@ -14,6 +14,10 @@ class RCTree:
     X: np.ndarray (n x d) (optional)
        Array containing n data points, each with dimension d.
        If no data provided, an empty tree is created.
+    random_state: int, RandomState instance or None (optional) (default=None)
+        If int, random_state is the seed used by the random number generator;
+        If RandomState instance, random_state is the random number generator;
+        If None, the random number generator is the RandomState instance used by np.random.
 
     Attributes:
     -----------

--- a/rrcf/rrcf.py
+++ b/rrcf/rrcf.py
@@ -56,9 +56,15 @@ class RCTree:
     >>> tree.forget_point(100)
     """
 
-    def __init__(self, X=None, index_labels=None, precision=9, seed=42):
+    def __init__(self, X=None, index_labels=None, precision=9, 
+                 random_state=None):
         # Random number generation with provided seed
-        self.rng = np.random.RandomState(seed)
+        if isinstance(random_state, int):
+            self.rng = np.random.RandomState(random_state)
+        elif isinstance(random_state, np.random.RandomState):
+            self.rng = random_state
+        else:
+            self.rng = np.random
         # Initialize dict for leaves
         self.leaves = {}
         # Initialize tree root

--- a/test/test_rrcf.py
+++ b/test/test_rrcf.py
@@ -11,6 +11,9 @@ Z[90:, :] = 1
 tree = rrcf.RCTree(X)
 duplicate_tree = rrcf.RCTree(Z)
 
+tree_seeded = rrcf.RCTree(random_state=0)
+duplicate_tree_seeded = rrcf.RCTree(random_state=np.random.RandomState(0))
+
 deck = np.arange(n, dtype=int)
 np.random.shuffle(deck)
 indexes = deck[:5]
@@ -128,3 +131,11 @@ def test_shingle():
     step_0 = next(shingle)
     step_1 = next(shingle)
     assert (step_0[1] == step_1[0]).all()
+
+def test_random_state():
+    # The two trees should have the exact same random-cuts
+    points = np.random.uniform(size=(100, 5))
+    for idx, point in enumerate(points):
+        tree_seeded.insert_point(point, idx)
+        duplicate_tree_seeded.insert_point(point, idx)
+    assert str(tree_seeded) == str(duplicate_tree_seeded)


### PR DESCRIPTION
Added an optional parameter to the constructor of RCTree, called "random_state". It can be int, an np.random.RandomState instance of None (default), like in all sklearn modules.

This allows for optional generation of the same tree, if the same seed (int or RandomState) is provided, which is incredibly useful (for writing tests etc.)
 