### PR TITLE
Add license to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(name='rrcf',
       author_email='mdbartos@umich.edu, abhiramm@umich.edu, stroutm@umich.edu',
       url='http://open-storm.org',
       packages=["rrcf"],
+      license="MIT",
       install_requires=[
           'numpy'
       ]


### PR DESCRIPTION
Fixes #75 

Adding MIT license to setup.py so that it is reflected corectly in `pypi`