### PR TITLE
ensure bbox_hat has right dimensions

### DIFF
--- a/rrcf/rrcf.py
+++ b/rrcf/rrcf.py
@@ -1101,7 +1101,7 @@ class RCTree:
         (0, 0.9758881798109296)
         """
         # Generate the bounding box
-        bbox_hat = np.empty(bbox.shape)
+        bbox_hat = np.empty((2, bbox.shape[1]))
         # Update the bounding box based on the internal point
         bbox_hat[0, :] = np.minimum(bbox[0, :], point)
         bbox_hat[-1, :] = np.maximum(bbox[-1, :], point)


### PR DESCRIPTION
When we have a single root label, the bounding box dimensions are `1xd`, not `2xd`.

This means that the logic to set the bounding boxes will result in a single point being evaluated for a cut, which will result in a non-optimal cut