### PR TITLE
Replace deprecated pkg_resources with importlib.metadata

### DIFF
--- a/rrcf/__init__.py
+++ b/rrcf/__init__.py
@@ -1,5 +1,8 @@
 from rrcf.rrcf import *
 from rrcf.shingle import shingle
-import pkg_resources
+from importlib.metadata import version, PackageNotFoundError
 
-__version__ = pkg_resources.get_distribution('rrcf').version
+try:
+    __version__ = version("rrcf")
+except PackageNotFoundError:
+    __version__ = "unknown"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='rrcf',
-      version='0.4.4',
+      version='0.4.5',
       description='Robust random cut forest for anomaly detection',
       author='Matt Bartos, Abhiram Mullapudi, Sara Troutman',
       author_email='mdbartos@umich.edu, abhiramm@umich.edu, stroutm@umich.edu',


### PR DESCRIPTION
The current implementation uses `pkg_resources.get_distribution()` to get the package version, which is now deprecated as officially stated in the [setuptools documentation](https://setuptools.pypa.io/en/latest/pkg_resources.html):

> Use of pkg_resources is deprecated in favor of [importlib.resources](https://docs.python.org/3.11/library/importlib.resources.html#module-importlib.resources), [importlib.metadata](https://docs.python.org/3.11/library/importlib.metadata.html#module-importlib.metadata) and their backports ([importlib_resources](https://pypi.org/project/importlib_resources), [importlib_metadata](https://pypi.org/project/importlib_metadata)). Some useful APIs are also provided by [packaging](https://pypi.org/project/packaging) (e.g. requirements and version parsing). Users should refrain from new usage of pkg_resources and should work to port to importlib-based solutions.

I've replaced `pkg_resources` with Python's standard library alternative:
```python
from importlib.metadata import version, PackageNotFoundError

try:
    __version__ = version("rrcf")
except PackageNotFoundError:
    __version__ = "unknown"
```

Thank you for your work on rrcf, it's a great package